### PR TITLE
Bump version and minor fixes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -278,6 +278,14 @@ function activate(context) {
       vscode.workspace.textDocuments.forEach(linter.lintDocument, linter);
     }, 200);
   }));
+
+  context.subscriptions.push(vscode.commands.registerCommand('lcc.toggleInformationLinting', () => {
+    linter.toggleInformationUnderlining()
+    linter.clearDiagnostics();
+    setTimeout(() => {
+      vscode.workspace.textDocuments.forEach(linter.lintDocument, linter);
+    }, 200);
+  }));
 }
 
 // class that enables the ability to go to the label definition

--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable warning underlining in LCC Assembly files"
+        },
+        "lccAssembly.enableInformationUnderlining": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable information underlining in LCC Assembly files"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "lettucegoblin",
   "displayName": "LCC-Tools",
   "description": "LCC syntax highlighting (Dos Reis version of LCC)",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "icon": "images/golden.png",
   "keywords": [
     "lcc",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "lettucegoblin",
   "displayName": "LCC-Tools",
   "description": "LCC syntax highlighting (Dos Reis version of LCC)",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "icon": "images/golden.png",
   "keywords": [
     "lcc",

--- a/src/AssemblyLinter.js
+++ b/src/AssemblyLinter.js
@@ -74,7 +74,7 @@ class AssemblyLinter {
             const validPattern =  new RegExp(`^${rule.validPattern}$`);
 
 
-            if(rule.multiLine === "true") {
+            if (rule.multiline === 'true') {
                 // validate multi-line rules for the current file
                 let match;
                 while (match = regex.exec(text)) {

--- a/src/AssemblyLinter.js
+++ b/src/AssemblyLinter.js
@@ -81,8 +81,8 @@ class AssemblyLinter {
                     }
 
                     const follower = match[1];
-                    const start = new vscode.Position(lineNumber, match.index + match[0].indexOf(follower));
-                    const end = new vscode.Position(lineNumber, match.index + match[0].indexOf(follower) + follower.length);
+                    const start = new vscode.Position(lineNumber, match.index + match[0].lastIndexOf(follower));
+                    const end = new vscode.Position(lineNumber, match.index + match[0].lastIndexOf(follower) + follower.length);
                     const range = new vscode.Range(start, end);
     
                     // Check if the line contains a semicolon before the match

--- a/src/AssemblyLinter.js
+++ b/src/AssemblyLinter.js
@@ -14,7 +14,7 @@ class AssemblyLinter {
                 return vscode.DiagnosticSeverity.Error;
             case 'warning':
                 return vscode.DiagnosticSeverity.Warning;
-            case 'info':
+            case 'information':
                 return vscode.DiagnosticSeverity.Information;
             case 'hint':
                 return vscode.DiagnosticSeverity.Hint;
@@ -34,6 +34,12 @@ class AssemblyLinter {
         const config = vscode.workspace.getConfiguration('lccAssembly');
         const enableWarningUnderlining = config.get('enableWarningUnderlining');
         config.update('enableWarningUnderlining', !enableWarningUnderlining, true);
+    }
+
+    toggleInformationUnderlining() {
+        const config = vscode.workspace.getConfiguration('lccAssembly');
+        const enableInformationUnderlining = config.get('enableInformationUnderlining');
+        config.update('enableInformationUnderlining', !enableInformationUnderlining, true);
     }
 
     lintCurrentDocument() {
@@ -56,10 +62,11 @@ class AssemblyLinter {
             return;
         }
 
-        // Check if error and warning underlining are enabled
+        // Check if error, warning, and/or information underlining are enabled
         const config = vscode.workspace.getConfiguration('lccAssembly');
         const enableErrorUnderlining = config.get('enableErrorUnderlining');
         const enableWarningUnderlining = config.get('enableWarningUnderlining');
+        const enableInformationUnderlining = config.get('enableInformationUnderlining');
 
         const diagnostics = [];
         const lines = document.getText().split('\n');
@@ -94,7 +101,9 @@ class AssemblyLinter {
                         const severity = this.severityStrToEnum(rule.severity.toLowerCase());
                         const diagnostic = new vscode.Diagnostic(range, message, severity);
                         if ((severity === vscode.DiagnosticSeverity.Error && enableErrorUnderlining) ||
-                            (severity === vscode.DiagnosticSeverity.Warning && enableWarningUnderlining)) {
+                            (severity === vscode.DiagnosticSeverity.Warning && enableWarningUnderlining) 
+                            || (severity === vscode.DiagnosticSeverity.Information && enableInformationUnderlining)
+                            ) {
                             diagnostics.push(diagnostic);
                         }
                     }
@@ -125,7 +134,9 @@ class AssemblyLinter {
                             const severity = this.severityStrToEnum(rule.severity.toLowerCase());
                             const diagnostic = new vscode.Diagnostic(range, message, severity);
                             if ((severity === vscode.DiagnosticSeverity.Error && enableErrorUnderlining) ||
-                                (severity === vscode.DiagnosticSeverity.Warning && enableWarningUnderlining)) {
+                                (severity === vscode.DiagnosticSeverity.Warning && enableWarningUnderlining) 
+                                || (severity === vscode.DiagnosticSeverity.Information && enableInformationUnderlining)
+                                ) {
                                 diagnostics.push(diagnostic);
                             }
                         }

--- a/src/rules.json
+++ b/src/rules.json
@@ -326,18 +326,68 @@
             "severity": "Error"
         },
         {
-            "name": "bad sp of mov sp, fp for function call",
-            "pattern": "(?:(?:push[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:push[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+fp[\\t ,]+sp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+(\\w+)[ ,]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:ret))",
-            "validPattern": "^(sp)$",
-            "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 45)",
-            "severity": "Error"
+            "name": "bad lr of push lr for function call",
+            "pattern": "(?:(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(lr)$",
+            "message": "The 'push lr' instruction must be used to save the link register before a function call, but got {follower} (code 45)",
+            "severity": "Warning",
+            "multiline": "true"
         },
         {
-            "name": "bad lr of push lr for function call",
-            "pattern": "(?:(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:push[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+fp[\\t ,]+sp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+sp[ ,]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:ret))",
+            "name": "bad fp of push fp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(fp)$",
+            "message": "The 'push fp' instruction must be used to save the frame pointer before a function call, but got {follower} (code 46)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad fp of mov fp, sp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+(\\w+)[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(fp)$",
+            "message": "The 'mov fp, sp' instruction must be used to set the frame pointer before a function call, but got {follower} (code 47)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad sp of mov fp, sp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+(\\w+))[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(sp)$",
+            "message": "The 'mov fp, sp' instruction must be used to set the frame pointer before a function call, but got {follower} (code 48)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad sp of mov sp, fp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+(\\w+)[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(sp)$",
+            "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 49)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad fp of mov sp, fp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+(\\w+))[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(fp)$",
+            "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 50)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad fp of pop fp for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(fp)$",
+            "message": "The 'pop fp' instruction must be used to restore the frame pointer after a function call, but got {follower} (code 51)",
+            "severity": "Warning",
+            "multiline": "true"
+        },
+        {
+            "name": "bad lr of pop lr for function call",
+            "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(lr)$",
-            "message": "The 'push lr' instruction must be used to save the link register before a function call, but got {follower} (code 46)",
-            "severity": "Error"
+            "message": "The 'pop lr' instruction must be used to restore the link register after a function call, but got {follower} (code 52)",
+            "severity": "Warning",
+            "multiline": "true"
         }
     ]
 }

--- a/src/rules.json
+++ b/src/rules.json
@@ -35,7 +35,7 @@
         {
             "name": "bad register for out mnemonics (non-number-starting catch-all)",
             "_COMMENT": "note that this pattern also captures errors for udout",
-            "pattern": "(?:dout|aout|hout|sout)[\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:dout|aout|hout|sout)[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|^$)$",
             "message": "out mnemonics must be followed by a valid register or nothing, but got {follower} (code 28)",
             "severity": "Error"
@@ -43,7 +43,7 @@
         {
             "name": "bad register for out mnemonics (number-starting catch-all)",
             "_COMMENT": "note that this pattern also captures errors for udout",
-            "pattern": "(?:dout|aout|hout|sout)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:dout|aout|hout|sout)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "validPattern": "^(fp|sp|lr|r[0-7]|^$)$",
             "message": "out mnemonics must be followed by a valid register or nothing, but got {follower} (code 29)",
             "severity": "Error"
@@ -78,14 +78,14 @@
         },
         {
             "name": "bad 2nd operand for mov (non-number-starting catch-all)",
-            "pattern": "mov[\\t ]+\\w+[,\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "mov[\\t ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+|0x[a-fA-F0-9]+|'\\\\?.')$",
             "message": "The 2nd operand of 'mov' must be a valid register, an integer, a hexadecimal number, or a single quote encapsulated char, but got {follower} (code 12)",
             "severity": "Error"
         },
         {
             "name": "bad 2nd operand for mov (number-starting catch-all)",
-            "pattern": "mov[\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "mov[\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+|0x[a-fA-F0-9]+|'\\\\?.')$",
             "message": "The 2nd operand of 'mov' must be a valid register, an integer, a hexadecimal number, or a single quote encapsulated char, but got {follower} (code 13)",
             "severity": "Error"
@@ -128,14 +128,14 @@
         },
         {
             "name": "bad 3rd operand for add/sub (non-number-starting catch-all)",
-            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+)$",
             "message": "The 3rd operand of 'add'/'sub' must be a valid register or an integer, but got {follower} (code 21)",
             "severity": "Error"
         },
         {
             "name": "bad 3rd operand for add/sub (number-starting catch-all)",
-            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+)$",
             "message": "The 3rd operand of 'add'/'sub' must be a valid register or an integer, but got {follower} (code 22)",
             "severity": "Error"
@@ -170,14 +170,14 @@
         },
         {
             "name": "bad operand for push/pop (non-number-starting catch-all)",
-            "pattern": "(?:push|pop)[\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:push|pop)[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7])$",
             "message": "The operand of 'push/pop' must be a valid register, but got {follower} (code 34)",
             "severity": "Error"
         },
         {
             "name": "bad operand for push/pop (number-starting catch-all)",
-            "pattern": "(?:push|pop)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "(?:push|pop)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "validPattern": "^(fp|sp|lr|r[0-7])$",
             "message": "The operand of 'push/pop' must be a valid register, but got {follower} (code 35)",
             "severity": "Error"
@@ -207,7 +207,7 @@
             "name": "bad mnemonic1",
             "_COMMENT": "captures mnemonic after a colon terminated label after a leading space",
             "pattern": "^[ ]+(?:[^:\\t\\n\\r ;]+:)[\\t ]*(\\w+)",
-            "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
+            "validPattern": "^(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)$",
             "message": "Invalid mnemonic or directive: {follower} (code 1)",
             "severity": "Error"
         },
@@ -215,15 +215,15 @@
             "name": "bad mnemonic2",
             "_COMMENT": "captures mnemonic after a colon terminating label that starts at the beginning of the line",
             "pattern": "^[^\\t ;]+:[\\t ]*([^:\\t\\n\\r ;]+)",
-            "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
+            "validPattern": "^(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)$",
             "message": "Invalid mnemonic or directive: {follower} (code 2)",
             "severity": "Error"
         },
         {
             "name": "bad mnemonic3",
             "_COMMENT": "captures mnemonic/mnemonic/directive that is not preceded by a label or a leading space",
-            "pattern": "^[\\t ]+((?![^:\\t ;]+:)[^:\\t ;]+\\b)",
-            "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
+            "pattern": "^[\\t ]+((?!\\S*[:])[^:\\t\\n\\r ;]+)",
+            "validPattern": "^(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)$",
             "message": "Invalid label, mnemonic, or directive: {follower} (code 3)",
             "severity": "Error"
         },
@@ -231,7 +231,7 @@
             "name": "bad mnemonic4",
             "_COMMENT": "captures mnemonic preceded by non-colon terminated label",
             "pattern": "^[^\\t ;:]+[\\t ]+([^:\\t\\n\\r ;]+)",
-            "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
+            "validPattern": "^(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)$",
             "message": "Invalid mnemonic or directive: {follower} (code 4)",
             "severity": "Error"
         },
@@ -269,7 +269,7 @@
         },
         {
             "name": "bad 2nd operand for cea (non-number-starting catch-all)",
-            "pattern": "cea[ ]+\\w+[,\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "cea[ ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "_COMMENT": "cea takes as its 2nd operand a number from -16 up to 15",
             "validPattern": "(-1[0-6]|-[1-9]|0|1[0-5]|[1-9])",
             "message": "The 2nd operand of 'cea' must be a number from -16 to 15, but got {follower} (code 43)",
@@ -277,7 +277,7 @@
         },
         {
             "name": "bad 2nd operand for cea (number-starting catch-all)",
-            "pattern": "cea[ ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "cea[ ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "_COMMENT": "cea takes as its 2nd operand a number from -16 up to 15",
             "validPattern": "(-1[0-6]|-[1-9]|0|1[0-5]|[1-9])",
             "message": "The 2nd operand of 'cea' must be a number from -16 to 15, but got {follower} (code 44)",
@@ -313,14 +313,14 @@
         },
         {
             "name": "bad operand for .string directive (non-number-starting catch-all)",
-            "pattern": "\\.string[\\t ]+((?:(?!(0x[;]+|[-?\\d]+)))(?!.*['\"])[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "\\.string[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(\".*\")$",
             "message": "The operand of '.string' must be a string, but got {follower} (code 15)",
             "severity": "Error"
         },
         {
             "name": "bad operand for .string direcive (number-starting catch-all)",
-            "pattern": "\\.string[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t]*[^\\n\\r\"'; \\t])",
+            "pattern": "\\.string[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
             "validPattern": "^(\".*\")$",
             "message": "The operand of '.string' must be a string, but got {follower} (code 16)",
             "severity": "Error"

--- a/src/rules.json
+++ b/src/rules.json
@@ -324,7 +324,20 @@
             "validPattern": "^(\".*\")$",
             "message": "The operand of '.string' must be a string, but got {follower} (code 16)",
             "severity": "Error"
+        },
+        {
+            "name": "bad sp of mov sp, fp for function call",
+            "pattern": "(?:(?:push[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:push[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+fp[\\t ,]+sp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+(\\w+)[ ,]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(sp)$",
+            "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 45)",
+            "severity": "Error"
+        },
+        {
+            "name": "bad lr of push lr for function call",
+            "pattern": "(?:(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:push[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+fp[\\t ,]+sp)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+sp[ ,]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+fp)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+lr)[\\t\\n\\r\\S ]+?(?:ret))",
+            "validPattern": "^(lr)$",
+            "message": "The 'push lr' instruction must be used to save the link register before a function call, but got {follower} (code 46)",
+            "severity": "Error"
         }
-
     ]
 }

--- a/src/rules.json
+++ b/src/rules.json
@@ -330,7 +330,7 @@
             "pattern": "(?:(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(lr)$",
             "message": "The 'push lr' instruction must be used to save the link register before a function call, but got {follower} (code 45)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -338,7 +338,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(fp)$",
             "message": "The 'push fp' instruction must be used to save the frame pointer before a function call, but got {follower} (code 46)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -346,7 +346,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+(\\w+)[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(fp)$",
             "message": "The 'mov fp, sp' instruction must be used to set the frame pointer before a function call, but got {follower} (code 47)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -354,7 +354,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+(\\w+))[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(sp)$",
             "message": "The 'mov fp, sp' instruction must be used to set the frame pointer before a function call, but got {follower} (code 48)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -362,7 +362,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+(\\w+)[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(sp)$",
             "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 49)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -370,7 +370,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+(\\w+))[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(fp)$",
             "message": "The 'mov sp, fp' instruction must be used to restore the stack pointer after a function call, but got {follower} (code 50)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -378,7 +378,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(fp)$",
             "message": "The 'pop fp' instruction must be used to restore the frame pointer after a function call, but got {follower} (code 51)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         },
         {
@@ -386,7 +386,7 @@
             "pattern": "(?:(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:push[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:mov[\\t ]+\\w+[\\t ,]+\\w+)[\\t\\n\\r\\S ]+(?:mov[\\t ]+\\w+[ ,]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+\\w+)[\\t\\n\\r\\S ]+?(?:pop[\\t ]+(\\w+))[\\t\\n\\r\\S ]+?(?:ret))",
             "validPattern": "^(lr)$",
             "message": "The 'pop lr' instruction must be used to restore the link register after a function call, but got {follower} (code 52)",
-            "severity": "Warning",
+            "severity": "Information",
             "multiline": "true"
         }
     ]

--- a/src/rules.json
+++ b/src/rules.json
@@ -198,7 +198,7 @@
         },
         {
             "name": "bad label not at line start",
-            "pattern": "^[\\t ]+([^;\\t :]+:)",
+            "pattern": "^[\\t ]+([^;\\t\\n\\r :]+:)",
             "validPattern": "[a-zA-Z_@$][a-zA-Z0-9_@$]*:",
             "message": "Invalid label {follower} found not at line start. Non-start labels must end with a colon, cannot begin with a number, and must contain only letters, numbers, '_', '$', and '@' (code 38)",
             "severity": "Error"
@@ -206,7 +206,7 @@
         {
             "name": "bad mnemonic1",
             "_COMMENT": "captures mnemonic after a colon terminated label after a leading space",
-            "pattern": "^[ ]+[^:\\t ;]+:[\\t ]*([^:\\t ;]+)",
+            "pattern": "^[ ]+(?:[^:\\t\\n\\r ;]+:)[\\t ]*(\\w+)",
             "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
             "message": "Invalid mnemonic or directive: {follower} (code 1)",
             "severity": "Error"
@@ -214,7 +214,7 @@
         {
             "name": "bad mnemonic2",
             "_COMMENT": "captures mnemonic after a colon terminating label that starts at the beginning of the line",
-            "pattern": "^[^\\t ;]+:[\\t ]*([^:\\t ;]+)",
+            "pattern": "^[^\\t ;]+:[\\t ]*([^:\\t\\n\\r ;]+)",
             "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
             "message": "Invalid mnemonic or directive: {follower} (code 2)",
             "severity": "Error"
@@ -230,7 +230,7 @@
         {
             "name": "bad mnemonic4",
             "_COMMENT": "captures mnemonic preceded by non-colon terminated label",
-            "pattern": "^[^\\t ;:]+[\\t ]+([^:\\t ;]+)",
+            "pattern": "^[^\\t ;:]+[\\t ]+([^:\\t\\n\\r ;]+)",
             "validPattern": "(cea|brn|mov|add|ld|st|bl|call|jsr|blr|jsrr|and|ldr|str|cmp|not|push|pop|srl|sra|sll|rol|ror|mul|div|rem|or|xor|mvr|sext|sub|jmp|ret|mvi|lea|halt|nl|dout|udout|hout|aout|sout|din|hin|ain|sin|brz|bre|brnz|brne|brne|brne|brp|brlt|brgt|brc|brb|br|bral|m|r|s|bp|.word|.zero|.blkw|.fill|.string|.asciz|.stringz|.space|.start|.global|.globl|.extern|.org)",
             "message": "Invalid mnemonic or directive: {follower} (code 4)",
             "severity": "Error"

--- a/src/rules.json
+++ b/src/rules.json
@@ -43,7 +43,7 @@
         {
             "name": "bad register for out mnemonics (number-starting catch-all)",
             "_COMMENT": "note that this pattern also captures errors for udout",
-            "pattern": "(?:dout|aout|hout|sout)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "(?:dout|aout|hout|sout)[\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "validPattern": "^(fp|sp|lr|r[0-7]|^$)$",
             "message": "out mnemonics must be followed by a valid register or nothing, but got {follower} (code 29)",
             "severity": "Error"
@@ -85,7 +85,7 @@
         },
         {
             "name": "bad 2nd operand for mov (number-starting catch-all)",
-            "pattern": "mov[\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "mov[\\t ]+\\w+[,\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+|0x[a-fA-F0-9]+|'\\\\?.')$",
             "message": "The 2nd operand of 'mov' must be a valid register, an integer, a hexadecimal number, or a single quote encapsulated char, but got {follower} (code 13)",
             "severity": "Error"
@@ -135,7 +135,7 @@
         },
         {
             "name": "bad 3rd operand for add/sub (number-starting catch-all)",
-            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+)$",
             "message": "The 3rd operand of 'add'/'sub' must be a valid register or an integer, but got {follower} (code 22)",
             "severity": "Error"
@@ -177,7 +177,7 @@
         },
         {
             "name": "bad operand for push/pop (number-starting catch-all)",
-            "pattern": "(?:push|pop)[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "(?:push|pop)[\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "validPattern": "^(fp|sp|lr|r[0-7])$",
             "message": "The operand of 'push/pop' must be a valid register, but got {follower} (code 35)",
             "severity": "Error"
@@ -277,7 +277,7 @@
         },
         {
             "name": "bad 2nd operand for cea (number-starting catch-all)",
-            "pattern": "cea[ ]+\\w+[,\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "cea[ ]+\\w+[,\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "_COMMENT": "cea takes as its 2nd operand a number from -16 up to 15",
             "validPattern": "(-1[0-6]|-[1-9]|0|1[0-5]|[1-9])",
             "message": "The 2nd operand of 'cea' must be a number from -16 to 15, but got {follower} (code 44)",
@@ -320,7 +320,7 @@
         },
         {
             "name": "bad operand for .string direcive (number-starting catch-all)",
-            "pattern": "\\.string[\\t ]+((?!0x)[\\d]+[\\w]+[^'\" \\t\\n\\r]*[^\\n\\r\"'; \\t,])",
+            "pattern": "\\.string[\\t ]+(?![^\\d])(?!0x)(?![^'\";\\t\\n\\r ]+['\"])(\\d+[^\\d';\"\\t\\n\\r ]+[^';\"\\t\\n\\r ]*)",
             "validPattern": "^(\".*\")$",
             "message": "The operand of '.string' must be a string, but got {follower} (code 16)",
             "severity": "Error"

--- a/src/rules.json
+++ b/src/rules.json
@@ -35,7 +35,7 @@
         {
             "name": "bad register for out mnemonics (non-number-starting catch-all)",
             "_COMMENT": "note that this pattern also captures errors for udout",
-            "pattern": "(?:dout|aout|hout|sout)[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "(?:dout|aout|hout|sout)[\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|^$)$",
             "message": "out mnemonics must be followed by a valid register or nothing, but got {follower} (code 28)",
             "severity": "Error"
@@ -78,7 +78,7 @@
         },
         {
             "name": "bad 2nd operand for mov (non-number-starting catch-all)",
-            "pattern": "mov[\\t ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "mov[\\t ]+\\w+[,\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+|0x[a-fA-F0-9]+|'\\\\?.')$",
             "message": "The 2nd operand of 'mov' must be a valid register, an integer, a hexadecimal number, or a single quote encapsulated char, but got {follower} (code 12)",
             "severity": "Error"
@@ -128,7 +128,7 @@
         },
         {
             "name": "bad 3rd operand for add/sub (non-number-starting catch-all)",
-            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "(?:add|sub)[\\t ]+\\w+[,\\t ]+\\w+[,\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7]|-?\\d+)$",
             "message": "The 3rd operand of 'add'/'sub' must be a valid register or an integer, but got {follower} (code 21)",
             "severity": "Error"
@@ -170,7 +170,7 @@
         },
         {
             "name": "bad operand for push/pop (non-number-starting catch-all)",
-            "pattern": "(?:push|pop)[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "(?:push|pop)[\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(fp|sp|lr|r[0-7])$",
             "message": "The operand of 'push/pop' must be a valid register, but got {follower} (code 34)",
             "severity": "Error"
@@ -269,7 +269,7 @@
         },
         {
             "name": "bad 2nd operand for cea (non-number-starting catch-all)",
-            "pattern": "cea[ ]+\\w+[,\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "cea[ ]+\\w+[,\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "_COMMENT": "cea takes as its 2nd operand a number from -16 up to 15",
             "validPattern": "(-1[0-6]|-[1-9]|0|1[0-5]|[1-9])",
             "message": "The 2nd operand of 'cea' must be a number from -16 to 15, but got {follower} (code 43)",
@@ -313,7 +313,7 @@
         },
         {
             "name": "bad operand for .string directive (non-number-starting catch-all)",
-            "pattern": "\\.string[\\t ]+(?!\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
+            "pattern": "\\.string[\\t ]+(?!-?\\d)(?![^'\";\\t\\n\\r ]+['\"])([^';\"\\t\\n\\r ]+)",
             "validPattern": "^(\".*\")$",
             "message": "The operand of '.string' must be a string, but got {follower} (code 15)",
             "severity": "Error"


### PR DESCRIPTION
This is a bunch of small fixes that address error captures that were inadvertently "doubling up". In other words, some terms were being highlighted with multiple errors where there was only one valid error to report. This was addressed mainly by making sure that single and double quotes were not present anywhere in the capture group.